### PR TITLE
added buy use case and base stock interactor

### DIFF
--- a/src/entities/CommonUser.java
+++ b/src/entities/CommonUser.java
@@ -10,12 +10,18 @@ public class CommonUser implements User {
     private final HashMap<String, TransactionHistory> history;
     private Double balance;
 
-    public void updatePortfolio(String ticker, Double amount) {
+    public void addToPortfolio(String ticker, Double amount) {
         portfolio.put(ticker, amount);
     }
-    public void removePortfolio(String ticker) {
+    public void removeFromPortfolio(String ticker) {
         portfolio.remove(ticker);
     }
+
+    @Override
+    public Boolean isInPortfolio(String ticker) {
+        return portfolio.containsKey(ticker);
+    }
+
     public Double getStockOwned(String ticker) {
         return portfolio.get(ticker);
     }

--- a/src/entities/User.java
+++ b/src/entities/User.java
@@ -6,8 +6,9 @@ public interface User {
     String getUsername();
     String getPassword();
     HashMap<String, TransactionHistory> getHistory();
-    void updatePortfolio(String ticker, Double amount);
-    void removePortfolio(String ticker);
+    void addToPortfolio(String ticker, Double amount);
+    void removeFromPortfolio(String ticker);
+    Boolean isInPortfolio(String ticker);
     Double getStockOwned(String ticker);
     boolean hasStock(String ticker);
     boolean hasEnough(Double amount);

--- a/src/use_cases/APIAccessInterface.java
+++ b/src/use_cases/APIAccessInterface.java
@@ -1,0 +1,19 @@
+package use_cases;
+
+import entities.CompanyInformation;
+import entities.CompanyNews;
+import entities.PricePoint;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface APIAccessInterface {
+    boolean isMarketOpen();
+    CompanyInformation getCompanyProfile(String ticker);
+    List<CompanyNews> getCompanyNews(String ticker, LocalDate from, LocalDate to);
+
+    PricePoint getCurrentPrice(String ticker); // called Quote in finnhub for example
+
+    // TODO check if we want to create specific methods for timeframes or generalize the resolution
+    List<PricePoint> getLastMonthPrices(String ticker); // the from and to can be calculated implicitly
+}

--- a/src/use_cases/BaseStockInteractor.java
+++ b/src/use_cases/BaseStockInteractor.java
@@ -1,0 +1,48 @@
+package use_cases;
+
+import entities.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public abstract class BaseStockInteractor {
+
+    protected final APIAccessInterface apiAccessInterface;
+
+    public BaseStockInteractor(APIAccessInterface apiAccessInterface) {
+        this.apiAccessInterface = apiAccessInterface;
+    }
+
+    protected TransactionHistory initHistory(User user, String ticker,
+                                              Double amount, Double boughtAt, Transaction transaction) {
+        List<PricePoint> lastMonthPrices = apiAccessInterface.getLastMonthPrices(ticker);
+        CompanyInformation companyInformation = apiAccessInterface.getCompanyProfile(ticker);
+        Stock newStock = new Stock(boughtAt, lastMonthPrices, companyInformation.getName(), ticker);
+
+        List<Transaction> transactions = new ArrayList<>();
+        transactions.add(transaction);
+
+        return new TransactionHistory(newStock, transactions);
+    }
+
+    protected void updatePortfolio(User user, String ticker, Double amount) {
+        if (amount == 0 && user.isInPortfolio(ticker)) {
+            user.removeFromPortfolio(ticker);
+        } else {
+            user.addToPortfolio(ticker, amount);
+        }
+    }
+
+    protected void addToHistory(HashMap<String, TransactionHistory> userHistory, String ticker,
+                                User user, Double amount, Double currentPrice, Transaction transaction) {
+        TransactionHistory transactionHistory;
+        if (!userHistory.containsKey(ticker)) {
+            transactionHistory = initHistory(user, ticker, amount, currentPrice, transaction);
+            userHistory.put(ticker, transactionHistory);
+        } else {
+            transactionHistory = userHistory.get(ticker);
+            transactionHistory.addTransaction(transaction);
+        }
+    }
+}

--- a/src/use_cases/Buy/BuyDataAccessInterface.java
+++ b/src/use_cases/Buy/BuyDataAccessInterface.java
@@ -1,0 +1,9 @@
+package use_cases.Buy;
+
+import entities.User;
+
+public interface BuyDataAccessInterface {
+    void save(User user);
+
+    User get(String username);
+}

--- a/src/use_cases/Buy/BuyInputBoundary.java
+++ b/src/use_cases/Buy/BuyInputBoundary.java
@@ -1,0 +1,5 @@
+package use_cases.Buy;
+
+public interface BuyInputBoundary {
+    void execute(BuyInputData buyInputData);
+}

--- a/src/use_cases/Buy/BuyInputData.java
+++ b/src/use_cases/Buy/BuyInputData.java
@@ -1,0 +1,25 @@
+package use_cases.Buy;
+
+public class BuyInputData {
+    public Double amount;
+    public String ticker;
+    public String username;
+
+    public BuyInputData(Double amount, String ticker, String username) {
+        this.amount = amount;
+        this.ticker = ticker;
+        this.username = username;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public String getTicker() {
+        return ticker;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/use_cases/Buy/BuyInteractor.java
+++ b/src/use_cases/Buy/BuyInteractor.java
@@ -1,0 +1,51 @@
+package use_cases.Buy;
+
+import entities.*;
+import interface_adapters.Buy.BuyOutputBoundary;
+import use_cases.APIAccessInterface;
+import use_cases.BaseStockInteractor;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+
+public class BuyInteractor extends BaseStockInteractor implements BuyInputBoundary {
+    final BuyDataAccessInterface userDataAccessObject;
+    BuyOutputBoundary buyPresenter;
+    APIAccessInterface driverAPI;
+
+    public BuyInteractor(BuyDataAccessInterface userDataAccessInterface,
+                         BuyOutputBoundary buyPresenter, APIAccessInterface driverAPI) {
+        super(driverAPI);
+        this.userDataAccessObject = userDataAccessInterface;
+        this.buyPresenter = buyPresenter;
+        this.driverAPI = driverAPI;
+    }
+
+    @Override
+    public void execute(BuyInputData buyInputData) {
+        String username = buyInputData.getUsername();
+        String ticker = buyInputData.getTicker();
+        Double amount = buyInputData.getAmount();
+
+        User user = userDataAccessObject.get(username);
+
+        Double currentPrice = driverAPI.getCurrentPrice(ticker).getPrice();
+
+        if (!user.hasEnough(currentPrice * amount)) {
+            buyPresenter.prepareFailView("You are broke. no money. no balance. no stock. no equity.");
+            return;
+        }
+
+        user.spendBalance(currentPrice * amount);
+        HashMap<String, TransactionHistory> userHistory = user.getHistory();
+
+        Transaction transaction = new BuyTransaction(amount, new PricePoint(LocalDate.now(), currentPrice));
+
+        super.updatePortfolio(user, ticker, amount);
+        super.addToHistory(userHistory, ticker, user, amount, currentPrice, transaction);
+        userDataAccessObject.save(user);
+
+        BuyOutputData result = new BuyOutputData(buyInputData.getAmount(), buyInputData.getTicker());
+        buyPresenter.prepareSuccessView(result);
+    }
+}

--- a/src/use_cases/Buy/BuyOutputData.java
+++ b/src/use_cases/Buy/BuyOutputData.java
@@ -1,0 +1,19 @@
+package use_cases.Buy;
+
+public class BuyOutputData {
+    public Double amount;
+    public String ticker;
+
+    public BuyOutputData(Double amount, String ticker) {
+        this.amount = amount;
+        this.ticker = ticker;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public String getTicker() {
+        return ticker;
+    }
+}

--- a/src/use_cases/DataAccessInterface.java
+++ b/src/use_cases/DataAccessInterface.java
@@ -1,0 +1,4 @@
+package use_cases;
+
+public interface DataAccessInterface {
+}

--- a/src/use_cases/GraphParser.java
+++ b/src/use_cases/GraphParser.java
@@ -1,0 +1,7 @@
+package use_cases;
+
+public class GraphParser {
+    public GraphParser() {
+
+    }
+}

--- a/src/use_cases/StocksAPI.java
+++ b/src/use_cases/StocksAPI.java
@@ -1,0 +1,23 @@
+package use_cases;
+
+import entities.PricePoint;
+import entities.Stock;
+
+import java.util.ArrayList;
+
+public class StocksAPI {
+
+    public String getStockInfo(String stockTicker) {
+        System.out.println("get stock info");
+        return "temp";
+    }
+
+    public Stock parseRawInfo(String[] info) {
+        return new Stock(0.0, new ArrayList<PricePoint>(), "f", "fa");
+    }
+
+    public static void main(String[] args) {
+        // TODO
+        // add API communication
+    }
+}


### PR DESCRIPTION
added buy use case and base stock interactor. added output data, api access interface, base stock interactor that will be used by all use cases, GraphParser for future use cases and graph handling

the buy use case relies on a user's name, stock they want to buy, and how much of it. then the current price is fetched from the API driver referenced to using the APIAccessInterface and the user's balance is compared against the current price. their balance is then deducted and, if they dont have a TransactionHistory for that ticker, a new TransactionHistory is created and a stock entity that connects the stock ticker to the entire transaction history the user has ever had with a stock.

also, the stock is added to their portfolio alongside the number of that stock they bought. afterward, their data is saved and the Presenter is asked to provide the success view