### PR TITLE
added basic setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # stonks - CSC207 course project
 
+## Installation Instructions
+
+1. Clone the repository using any CLI with git installed using "git clone https://github.com/awesominat/stonks.git" (alternatively, you can download the repo)
+2. Install all necessary packages (OkHttp, json)
+3. Create an account over on [Finnhub](finnhub.io) and copy your API key
+4. Create a file called file.txt and insert the key and nothing else (no spaces)
+5. Open src/app/main, and run the file
 
 ## General Description
 The broad purpose of the software is to give users a platform to invest in stocks, view their profits, view stock price 
@@ -7,30 +14,29 @@ trends, and copy other users portfolio investments, all using fake money to remo
 
 Our software attempts to solve the problem investors have when they want to practice investing risk-free.
 
-
 ## User Stories
 
-### Team User Story (Buy use case)
+User Story 1:
 As a stock investor ready to start my investment journey, I would like to buy any number of a specific stock and have 
 the stocks I’ve bought saved so I don’t lose my investments. This feature will allow me to test my theories in stock 
 investments so I can be better prepared when I spend my real money.
 
-### Stephen User Story (ResetBalance use case)
+User Story 2:
 As an investor who has lost all my money, I would like to reset my account so that I can start over again since the 
 imaginary investments I have made through the Stonks™ app did not go as I had hoped, and I now wish to simulate other 
 investment strategies.
 
-### Zain User Story (StockInfo use case)
+User Story 3:
 As an investor interested in buying a stock, I would like to view comprehensive information about that specific stock, 
 such as their previous prices, current prices, and percentage change in the last day, so I can make an informed decision 
 about how to spend my money.
 
-### Ricky User Story (ViewPortfolio use case)
+User Story 4:
 As a finance enthusiast worried about whether I made the right choice buying a stock, I would like an intuitive overview 
 of all the stocks I am currently invested in and how they are performing. As in, I would like to see the percentage 
 profit or loss for every stock I have purchased.
 
-### Gursimar User Story (Sell use case)
+User Story 5:
 As an aspiring investor who understands the stock market is changing rapidly, I would like to conveniently sell stock 
 using the fake money in my portfolio and know how much I have profited/lost from what stocks (of what company) as well 
 as how much money my account will have after I sell. These features are so that I can effectively track how well I am 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 1. Clone the repository using any CLI with git installed using "git clone https://github.com/awesominat/stonks.git" (alternatively, you can download the repo)
 2. Install all necessary packages (OkHttp, json)
 3. Create an account over on [Finnhub](finnhub.io) and copy your API key
-4. Create a file called file.txt and insert the key and nothing else (no spaces)
+4. Create a file called file.txt in the root directory and insert the key and nothing else (no spaces)
 5. Open src/app/main, and run the file
 
 ## General Description


### PR DESCRIPTION
We should look into better ways of instructing the client on how to download the Maven dependencies, as we will have to update the README.md each time we want to add a new dependency.

These instructions are very basic at the moment, but should serve as a base going forward