### PR TITLE
GetNews use case implemented. Interface adapters still pending.

### DIFF
--- a/src/entities/CompanyNews.java
+++ b/src/entities/CompanyNews.java
@@ -17,6 +17,16 @@ public class CompanyNews {
         this.summary = summary;
     }
 
+    public String getCategory() {return category;}
+
+    public LocalDate getDatetime() {return datetime;}
+
+    public String getHeadline() {return headline;}
+
+    public String getUrl() {return url;}
+
+    public String getSummary() {return summary;}
+
     public String toString() {
         return "CompanyNews{\n" +
                 "category='" + this.category + "', \n" +

--- a/src/use_cases/GetNews/GetNewsDataAccessInterface.java
+++ b/src/use_cases/GetNews/GetNewsDataAccessInterface.java
@@ -1,0 +1,5 @@
+package use_cases.GetNews;
+
+// TODO delete this I guess
+public interface GetNewsDataAccessInterface {
+}

--- a/src/use_cases/GetNews/GetNewsInputBoundary.java
+++ b/src/use_cases/GetNews/GetNewsInputBoundary.java
@@ -1,0 +1,5 @@
+package use_cases.GetNews;
+
+public interface GetNewsInputBoundary {
+    void execute(GetNewsInputData getNewsInputData);
+}

--- a/src/use_cases/GetNews/GetNewsInputData.java
+++ b/src/use_cases/GetNews/GetNewsInputData.java
@@ -1,0 +1,13 @@
+package use_cases.GetNews;
+
+public class GetNewsInputData {
+    public String ticker;
+
+    public GetNewsInputData(String ticker) {
+        this.ticker = ticker;
+    }
+
+    public String getTicker() {
+        return ticker;
+    }
+}

--- a/src/use_cases/GetNews/GetNewsInteractor.java
+++ b/src/use_cases/GetNews/GetNewsInteractor.java
@@ -1,0 +1,49 @@
+package use_cases.GetNews;
+
+import entities.CompanyNews;
+import use_cases.APIAccessInterface;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class GetNewsInteractor implements GetNewsInputBoundary {
+    GetNewsOutputBoundary getNewsPresenter;
+    APIAccessInterface driverAPI;
+
+    public GetNewsInteractor(GetNewsOutputBoundary getNewsPresenter, APIAccessInterface driverAPI) {
+        this.getNewsPresenter = getNewsPresenter;
+        this.driverAPI = driverAPI;
+    }
+
+    @Override
+    public void execute(GetNewsInputData getNewsInputData) {
+        /**
+        * The getNewsInputData parameter should follow the specifications laid out in that class.
+        * <p>
+        * This method implements the bulk of the GetNews use case.
+        * News is fetched over a time period of a month prior to the method call.
+        *
+        * @param  getNewsInputData  an InputData object following the relevant CA Engine rules
+        */
+        String ticker = getNewsInputData.getTicker();
+
+        // Define end of news period to be right now
+        LocalDate to = LocalDate.now();
+        // Define start of news period to be a month ago
+        LocalDate from = to.minusMonths(1);
+
+        try {
+            // Make API call
+            List<CompanyNews> company_news_list = driverAPI.getCompanyNews(ticker, from, to);
+
+            // Save API output using OutputData format for the GetNews use case
+            GetNewsOutputData result = new GetNewsOutputData(ticker, company_news_list);
+
+            getNewsPresenter.prepareSuccessView(result);
+
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            getNewsPresenter.prepareFailView("something happened");
+        }
+    }
+}

--- a/src/use_cases/GetNews/GetNewsOutputBoundary.java
+++ b/src/use_cases/GetNews/GetNewsOutputBoundary.java
@@ -1,0 +1,7 @@
+package use_cases.GetNews;
+
+public interface GetNewsOutputBoundary {
+    void prepareSuccessView(GetNewsOutputData result);
+
+    void prepareFailView(String error);
+}

--- a/src/use_cases/GetNews/GetNewsOutputData.java
+++ b/src/use_cases/GetNews/GetNewsOutputData.java
@@ -1,0 +1,36 @@
+package use_cases.GetNews;
+
+import entities.CompanyNews;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+
+public class GetNewsOutputData {
+    String ticker;
+    List<Map<String, String>> news_items;
+
+    public GetNewsOutputData(String ticker, List<CompanyNews> company_news_items) {
+        this.ticker = ticker;
+        this.news_items = new ArrayList<Map<String, String>>();
+        for (CompanyNews company_news : company_news_items) {
+            Map<String, String> news_item = new HashMap<>();
+
+            news_item.put("category", company_news.getCategory());
+            news_item.put("datetime", company_news.getDatetime().toString());
+            news_item.put("headline", company_news.getHeadline());
+            news_item.put("url", company_news.getUrl());
+            news_item.put("summary", company_news.getSummary());
+
+            this.news_items.add(news_item);
+        }
+    }
+
+    public String getTicker() {return ticker;}
+
+    public List<Map<String, String>> getNewsItems() {return news_items;}
+
+    // TODO decide whether this is necessary
+    // public Map<String, String> getNewsItem(int idx) {return news_items.get(idx);}
+}


### PR DESCRIPTION
I have implemented the use case for GetNews, including all the CA Engine modules in the use case portion of the diagram. The GetNewsDataAccessInterface may need to be deprecated, as it is not required for the use case interactor. 

The CompanyNews entity was modified to be able to return private attributes as required by the OutputData module of GetNews. 

This is a large chunk of the resolution to Issue #30. 