### PR TITLE
login_deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ file.txt
 .idea/**/dictionaries
 .idea/**/shelf
 csc207-project.iml
-users.csv
+# users.csv  # this needs to be a common file now cuz we have only one local user
 
 # AWS User-specific
 .idea/**/aws.xml
@@ -195,6 +195,5 @@ tags
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij+all,java,macos,visualstudiocode,vim
 
-# Stephen's addition #
-# Ignore Stephen's commit executable
-./git-commit.sh
+## Stephen's personal necessity ##
+help.txt

--- a/src/interface_adapters/Login/LoginController.java
+++ b/src/interface_adapters/Login/LoginController.java
@@ -1,2 +1,0 @@
-package interface_adapters.Login;public class LoginController {
-}

--- a/src/interface_adapters/Login/LoginPresenter.java
+++ b/src/interface_adapters/Login/LoginPresenter.java
@@ -1,2 +1,0 @@
-package interface_adapters.Login;public class LoginPresenter {
-}

--- a/src/use_cases/Login/LoginInputBoundary.java
+++ b/src/use_cases/Login/LoginInputBoundary.java
@@ -1,2 +1,0 @@
-package use_cases.Login;public interface LoginInputBoundary {
-}

--- a/src/use_cases/Login/LoginInputData.java
+++ b/src/use_cases/Login/LoginInputData.java
@@ -1,2 +1,0 @@
-package use_cases.Login;public class LoginInputData {
-}

--- a/src/use_cases/Login/LoginInteractor.java
+++ b/src/use_cases/Login/LoginInteractor.java
@@ -1,2 +1,0 @@
-package use_cases.Login;public class LoginInteractor {
-}

--- a/src/use_cases/Login/LoginOutputBoundary.java
+++ b/src/use_cases/Login/LoginOutputBoundary.java
@@ -1,2 +1,0 @@
-package use_cases.Login;public interface LoginOutputBoundary {
-}

--- a/src/use_cases/Login/LoginOutputData.java
+++ b/src/use_cases/Login/LoginOutputData.java
@@ -1,2 +1,0 @@
-package use_cases.Login;public class LoginOutputData {
-}

--- a/src/use_cases/Login/LoginUserDataAccessInterface.java
+++ b/src/use_cases/Login/LoginUserDataAccessInterface.java
@@ -1,2 +1,0 @@
-package use_cases.Login;public interface LoginUserDataAccessInterface {
-}

--- a/users.csv
+++ b/users.csv
@@ -1,0 +1,2 @@
+username,password
+local_user,local_user


### PR DESCRIPTION
Deleted the login use case and interface adapters. Added default user `"local_user"`. 

Did not delete `data_access/UserSignupDataAccessInterface` because it is tied into other modules and packages and it does not cause any problems the way it is. The idea of this pull request is to replace the signup process with a behind-the-scenes default process that automatically creates a local user through which the user will interact with our program. 

In the future, most of the data access objects and interfaces will most likely be significantly modified to remove the infrastructure of multiple users altogether, and replace this with a single User object. 