### PR TITLE
Changed behaviour of ResetBalance usecase so that user can reset whenever

### DIFF
--- a/src/main/java/use_cases/ResetBalance/ResetBalanceInteractor.java
+++ b/src/main/java/use_cases/ResetBalance/ResetBalanceInteractor.java
@@ -25,12 +25,6 @@ public class ResetBalanceInteractor extends BaseStockInteractor implements Reset
         String username = sellInputData.getUsername();
 
         User user = userDataAccessObject.get();
-
-        if (user.getBalance() >= 500.0) {
-            resetBalancePresenter.prepareFailView("You have way too much money.");
-            return;
-        }
-
         Double curBalance = user.getBalance();
         Double amountToAdd = 10000.0;
         user.addBalance(amountToAdd);


### PR DESCRIPTION
As discussed in our previous meeting, the user should be able to reset whenever so I got rid of the condition where it checks whether the user's balance is less than or equal to 500.