### PR TITLE
Typo in Dashboard use case fixed

### DIFF
--- a/src/main/java/use_cases/Dashboard/DashboardOutputData.java
+++ b/src/main/java/use_cases/Dashboard/DashboardOutputData.java
@@ -18,7 +18,7 @@ public class DashboardOutputData {
         return this.userStats;
     }
 
-    public List<PortfolioInformation> getPortfolioInformations() {
+    public List<PortfolioInformation> getPortfolioInformation() {
         return this.portfolioInformation;
     }
 }


### PR DESCRIPTION
There was a typo in `DashboardOutputData` that has now been resolved.