### PR TITLE
Changed Output Data so that we don't violate Inward Dependency Rule

### DIFF
--- a/src/main/java/interface_adapters/Dashboard/DashboardPresenter.java
+++ b/src/main/java/interface_adapters/Dashboard/DashboardPresenter.java
@@ -18,8 +18,11 @@ public class DashboardPresenter implements DashboardOutputBoundary {
     public void prepareSuccessView(DashboardOutputData dashboardOutputData) {
         // Get the current dashboardViewModel's state
         DashboardState dashboardState = dashboardViewModel.getState();
-        // Alter the state such that it updates to the new portfolioInformation and user stats
-        dashboardState.setOwnedStocks(dashboardOutputData.getPortfolioInformation());
+        // Alter the state such that it updates to the new ticker, amount, and full name info
+        // and user stats
+        dashboardState.setOwnedAmounts(dashboardOutputData.getAmountInformation());
+        dashboardState.setOwnedTickers(dashboardOutputData.getTickerInformation());
+        dashboardState.setOwnedFullNames(dashboardOutputData.getFullNamesInformation());
         dashboardState.setUserStats(dashboardOutputData.getUserStats());
         // fire the property changed for dashboard view model
         dashboardViewModel.firePropertyChanged();

--- a/src/main/java/interface_adapters/Dashboard/DashboardState.java
+++ b/src/main/java/interface_adapters/Dashboard/DashboardState.java
@@ -7,15 +7,40 @@ import java.util.List;
 public class DashboardState {
     private HashMap<String, Double> userStats;
     // change owned stocks data type
-    private List<PortfolioInformation> ownedStocks;
+    private List<String> ownedTickers;
+    private List<String> ownedFullNames;
+    private List<Double> ownedAmounts;
 
-    public DashboardState(HashMap<String, Double> userStats, List<PortfolioInformation> ownedStocks) {
+    public DashboardState(HashMap<String, Double> userStats, List<String> ownedTickers,
+                          List<String> ownedFullNames, List<Double> ownedAmounts) {
         this.userStats = userStats;
-        this.ownedStocks = ownedStocks;
+        this.ownedTickers = ownedTickers;
+        this.ownedAmounts = ownedAmounts;
+        this.ownedFullNames = ownedFullNames;
     }
 
-    public List<PortfolioInformation> getOwnedStocks() {
-        return this.ownedStocks;
+    public List<Double> getOwnedAmounts() {
+        return this.ownedAmounts;
+    }
+
+    public void setOwnedAmounts(List<Double> ownedAmounts) {
+        this.ownedAmounts = ownedAmounts;
+    }
+
+    public List<String> getOwnedTickers() {
+        return ownedTickers;
+    }
+
+    public void setOwnedTickers(List<String> ownedTickers) {
+        this.ownedTickers = ownedTickers;
+    }
+
+    public List<String> getOwnedFullNames() {
+        return ownedFullNames;
+    }
+
+    public void setOwnedFullNames(List<String> ownedFullNames) {
+        this.ownedFullNames = ownedFullNames;
     }
 
     public HashMap<String, Double> getUserStats() {
@@ -26,9 +51,6 @@ public class DashboardState {
         this.userStats = userStats;
     }
 
-    public void setOwnedStocks(List<PortfolioInformation> ownedStocks) {
-        this.ownedStocks = ownedStocks;
-    }
 
     // Because of the previous copy constructor, the default constructor must be explicit. Hence overloading.
     public DashboardState() {

--- a/src/main/java/use_cases/Dashboard/DashboardOutputBoundary.java
+++ b/src/main/java/use_cases/Dashboard/DashboardOutputBoundary.java
@@ -1,4 +1,4 @@
-package interface_adapters.Dashboard;
+package use_cases.Dashboard;
 
 import use_cases.Dashboard.DashboardOutputData;
 

--- a/src/main/java/use_cases/Dashboard/DashboardOutputData.java
+++ b/src/main/java/use_cases/Dashboard/DashboardOutputData.java
@@ -2,6 +2,7 @@ package use_cases.Dashboard;
 
 import entities.PortfolioInformation;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -18,7 +19,31 @@ public class DashboardOutputData {
         return this.userStats;
     }
 
-    public List<PortfolioInformation> getPortfolioInformations() {
-        return this.portfolioInformation;
+    public List<String> getTickerInformation() {
+        List<String> tickers = new ArrayList<String>();
+
+        for (PortfolioInformation pdata: portfolioInformation) {
+            tickers.add(pdata.getTicker());
+        }
+        return tickers;
+    }
+
+
+    public List<String> getFullNamesInformation() {
+        List<String> fullNames = new ArrayList<String>();
+
+        for (PortfolioInformation pdata: portfolioInformation) {
+            fullNames.add(pdata.getFullName());
+        }
+        return fullNames;
+    }
+
+    public List<Double> getAmountInformation() {
+        List<Double> amount = new ArrayList<Double>();
+
+        for (PortfolioInformation pdata: portfolioInformation) {
+            amount.add(pdata.getAmount());
+        }
+        return amount;
     }
 }


### PR DESCRIPTION
Previously, we were using the portfolioInformation data type (stored in the entity) in the interface adapter level. This has been changed so we do not violate the Dependency Rule.