### PR TITLE
View names fixed

### DIFF
--- a/src/main/java/interface_adapters/Buy/BuyViewModel.java
+++ b/src/main/java/interface_adapters/Buy/BuyViewModel.java
@@ -15,7 +15,7 @@ public class BuyViewModel extends ViewModel {
     private BuyState state = new BuyState();
 
     public BuyViewModel() {
-        super("Buy Stock");
+        super("buy");
     }
 
     public void setState(BuyState state) {

--- a/src/main/java/interface_adapters/GetNews/GetNewsViewModel.java
+++ b/src/main/java/interface_adapters/GetNews/GetNewsViewModel.java
@@ -11,7 +11,7 @@ public class GetNewsViewModel extends ViewModel {
 
     private GetNewsState state = new GetNewsState();
 
-    public GetNewsViewModel() {super("Get Company News");}
+    public GetNewsViewModel() {super("news");}
 
     public void setState(GetNewsState state) {
         this.state = state;

--- a/src/main/java/interface_adapters/ResetBalance/ResetBalanceViewModel.java
+++ b/src/main/java/interface_adapters/ResetBalance/ResetBalanceViewModel.java
@@ -12,7 +12,7 @@ public class ResetBalanceViewModel extends ViewModel {
     private ResetBalanceState state = new ResetBalanceState();
 
     public ResetBalanceViewModel() {
-        super("Reset Balance");
+        super("reset");
     }
 
     public void setState(ResetBalanceState state) {

--- a/src/main/java/interface_adapters/Sell/SellViewModel.java
+++ b/src/main/java/interface_adapters/Sell/SellViewModel.java
@@ -14,7 +14,7 @@ public class SellViewModel extends ViewModel {
     private SellState state = new SellState();
 
     public SellViewModel() {
-        super("Sell Stock");
+        super("sell");
     }
 
     public void setState(SellState state) {

--- a/src/main/java/view/BuyView.java
+++ b/src/main/java/view/BuyView.java
@@ -14,7 +14,7 @@ import java.beans.PropertyChangeListener;
 
 public class BuyView extends JPanel implements ActionListener, PropertyChangeListener {
 
-    public final String viewName = "Buy Stock";
+    public final String viewName = "buy";
     private final BuyViewModel buyViewModel;
 
     /**

--- a/src/main/java/view/GetNewsView.java
+++ b/src/main/java/view/GetNewsView.java
@@ -14,7 +14,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
 public class GetNewsView extends JPanel implements ActionListener, PropertyChangeListener {
-    public final String viewName = "Get Company News";
+    public final String viewName = "news";
     private final GetNewsViewModel getNewsViewModel;
 
     /**

--- a/src/main/java/view/ResetBalanceView.java
+++ b/src/main/java/view/ResetBalanceView.java
@@ -11,7 +11,7 @@ import java.beans.PropertyChangeListener;
 
 public class ResetBalanceView extends JPanel implements ActionListener, PropertyChangeListener {
 
-    public final String viewName = "Reset Balance";
+    public final String viewName = "reset";
     private final ResetBalanceViewModel resetBalanceViewModel;
     private final JLabel statusErrorField = new JLabel();
     ;


### PR DESCRIPTION
I fixed all the viewName attributes in the ViewModels and the Views to match the convention of one-word, lowercase. 

Dashboard's viewName was not fixed because there is a PR pending that already addressed this. 