### PR TITLE
View Names Fixed

### DIFF
--- a/src/main/java/interface_adapters/Buy/BuyViewModel.java
+++ b/src/main/java/interface_adapters/Buy/BuyViewModel.java
@@ -15,7 +15,7 @@ public class BuyViewModel extends ViewModel {
     private BuyState state = new BuyState();
 
     public BuyViewModel() {
-        super("Buy Stock");
+        super("buy");
     }
 
     public void setState(BuyState state) {

--- a/src/main/java/interface_adapters/ResetBalance/ResetBalanceViewModel.java
+++ b/src/main/java/interface_adapters/ResetBalance/ResetBalanceViewModel.java
@@ -12,7 +12,7 @@ public class ResetBalanceViewModel extends ViewModel {
     private ResetBalanceState state = new ResetBalanceState();
 
     public ResetBalanceViewModel() {
-        super("Reset Balance");
+        super("reset");
     }
 
     public void setState(ResetBalanceState state) {

--- a/src/main/java/interface_adapters/Sell/SellViewModel.java
+++ b/src/main/java/interface_adapters/Sell/SellViewModel.java
@@ -14,7 +14,7 @@ public class SellViewModel extends ViewModel {
     private SellState state = new SellState();
 
     public SellViewModel() {
-        super("Sell Stock");
+        super("sell");
     }
 
     public void setState(SellState state) {

--- a/src/main/java/view/BuyView.java
+++ b/src/main/java/view/BuyView.java
@@ -14,7 +14,7 @@ import java.beans.PropertyChangeListener;
 
 public class BuyView extends JPanel implements ActionListener, PropertyChangeListener {
 
-    public final String viewName = "Buy Stock";
+    public final String viewName = "buy";
     private final BuyViewModel buyViewModel;
 
     /**

--- a/src/main/java/view/DashboardView.java
+++ b/src/main/java/view/DashboardView.java
@@ -12,7 +12,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
 public class DashboardView extends JPanel implements ActionListener, PropertyChangeListener {
-    public final String viewName = "Dashboard";
+    public final String viewName = "dashboard";
     private final DashboardViewModel dashboardViewModel;
     private final ViewManagerModel viewManagerModel;
 

--- a/src/main/java/view/ResetBalanceView.java
+++ b/src/main/java/view/ResetBalanceView.java
@@ -11,7 +11,7 @@ import java.beans.PropertyChangeListener;
 
 public class ResetBalanceView extends JPanel implements ActionListener, PropertyChangeListener {
 
-    public final String viewName = "Reset Balance";
+    public final String viewName = "reset";
     private final ResetBalanceViewModel resetBalanceViewModel;
     private final JLabel statusErrorField = new JLabel();
     ;
@@ -25,7 +25,7 @@ public class ResetBalanceView extends JPanel implements ActionListener, Property
         this.resetBalanceViewModel = resetBalanceViewModel;
         this.resetBalanceViewModel.addPropertyChangeListener(this);
 
-        JLabel title = new JLabel("reset");
+        JLabel title = new JLabel(resetBalanceViewModel.TITLE_LABEL);
         title.setAlignmentX(Component.CENTER_ALIGNMENT);
 
         JPanel buttons = new JPanel();

--- a/src/main/java/view/ResetBalanceView.java
+++ b/src/main/java/view/ResetBalanceView.java
@@ -25,7 +25,7 @@ public class ResetBalanceView extends JPanel implements ActionListener, Property
         this.resetBalanceViewModel = resetBalanceViewModel;
         this.resetBalanceViewModel.addPropertyChangeListener(this);
 
-        JLabel title = new JLabel("Sell Stock");
+        JLabel title = new JLabel("reset");
         title.setAlignmentX(Component.CENTER_ALIGNMENT);
 
         JPanel buttons = new JPanel();


### PR DESCRIPTION
I updated the `viewName` attribute of each view to match the naming convention we decided upon (which was lowercase, one-word). This should not affect anything else since view names should be referenced through the view model without directly quoting a string anyways. 

I had to fix the view models and the views in this regard. Everything is now coherent. 

IMPORTANT NOTE: In reviewing the Views and ViewModels for this Issue, I discovered that most of them are far from complete, so much progress needs be made with respect to the view and view models very soon if we want to start testing our UI. 