### PR TITLE
removed unnecessary API methods to run faster

### DIFF
--- a/src/main/java/entities/Stock.java
+++ b/src/main/java/entities/Stock.java
@@ -8,9 +8,8 @@ public class Stock {
     final private String fullName;
     final private String ticker;
 
-    public Stock(Double lastSeenPrice, List<PricePoint> priceHistory, String fullName, String ticker) {
+    public Stock(Double lastSeenPrice, String fullName, String ticker) {
         this.lastSeenPrice = lastSeenPrice;
-        this.priceHistory = priceHistory;
         this.fullName = fullName;
         this.ticker = ticker;
     }

--- a/src/main/java/use_cases/APIAccessInterface.java
+++ b/src/main/java/use_cases/APIAccessInterface.java
@@ -14,6 +14,4 @@ public interface APIAccessInterface {
 
     PricePoint getCurrentPrice(String ticker); // called Quote in finnhub for example
 
-    // TODO check if we want to create specific methods for timeframes or generalize the resolution
-    List<PricePoint> getLastMonthPrices(String ticker); // the from and to can be calculated implicitly
 }

--- a/src/main/java/use_cases/BaseStockInteractor.java
+++ b/src/main/java/use_cases/BaseStockInteractor.java
@@ -16,9 +16,8 @@ public abstract class BaseStockInteractor {
 
     protected TransactionHistory initHistory(User user, String ticker,
                                              Double amount, Double boughtAt, Transaction transaction) {
-        List<PricePoint> lastMonthPrices = apiAccessInterface.getLastMonthPrices(ticker);
         CompanyInformation companyInformation = apiAccessInterface.getCompanyProfile(ticker);
-        Stock newStock = new Stock(boughtAt, lastMonthPrices, companyInformation.getName(), ticker);
+        Stock newStock = new Stock(boughtAt, companyInformation.getName(), ticker);
 
         List<Transaction> transactions = new ArrayList<>();
         transactions.add(transaction);

--- a/src/test/java/buySellTest.java
+++ b/src/test/java/buySellTest.java
@@ -30,14 +30,10 @@ public class buySellTest {
         APIAccessInterface mockApi = Mockito.mock(APIAccessInterface.class);
         BuyDataAccessInterface userDataAccessObject = Mockito.mock(BuyDataAccessInterface.class);
 
-        List<PricePoint> lastMonthPrices = new ArrayList<>();
-        lastMonthPrices.add(new PricePoint(LocalDate.now(), 100.0));
-
         Mockito.when(userDataAccessObject.get()).thenReturn(new CommonUser());
         Mockito.when(mockApi.getCurrentPrice("AAPL")).thenReturn(new PricePoint(LocalDate.now(), 100.0));
         Mockito.when(mockApi.getCompanyProfile("AAPL")).thenReturn(new CompanyInformation("US",
                 "Apple Inc", "AAPL", "https://www.apple.com/", "1980-12-12"));
-        Mockito.when(mockApi.getLastMonthPrices("AAPL")).thenReturn(lastMonthPrices);
 
         BuyInputData buyInputData = new BuyInputData(10.0, "AAPL");
 
@@ -62,9 +58,6 @@ public class buySellTest {
         APIAccessInterface mockApi = Mockito.mock(APIAccessInterface.class);
         SellDataAccessInterface userDataAccessObject = Mockito.mock(SellDataAccessInterface.class);
 
-        List<PricePoint> lastMonthPrices = new ArrayList<>();
-        lastMonthPrices.add(new PricePoint(LocalDate.now(), 100.0));
-
         User mockUser = new CommonUser();
         mockUser.addToPortfolio("AAPL", 10.0);
 
@@ -73,7 +66,6 @@ public class buySellTest {
         Mockito.when(mockApi.getCurrentPrice("AAPL")).thenReturn(new PricePoint(LocalDate.now(), 100.0));
         Mockito.when(mockApi.getCompanyProfile("AAPL")).thenReturn(new CompanyInformation("US",
                 "Apple Inc", "AAPL", "https://www.apple.com/", "1980-12-12"));
-        Mockito.when(mockApi.getLastMonthPrices("AAPL")).thenReturn(lastMonthPrices);
 
         SellInputData sellInputData = new SellInputData(10.0, "AAPL");
 


### PR DESCRIPTION
our api provider will remove the stock candle feature which will make getting the last month prices impossible unless we pay for a subscription, which we will not.

as such, the graph feature will be entirely removed. to finalize that change, we have to remove the last month prices from each stock initialization. (done by this PR)

this will also make our API calls during the dashboard much faster