### PR TITLE
sped up the back button by 2x by removing unnecessary API call

### DIFF
--- a/src/main/java/use_cases/Dashboard/DashboardInteractor.java
+++ b/src/main/java/use_cases/Dashboard/DashboardInteractor.java
@@ -33,6 +33,7 @@ public class DashboardInteractor extends BaseStockInteractor implements Dashboar
         List<PortfolioInformation> portfolioInformations = new ArrayList<>();
 
         Double accountBalance = user.getBalance();
+        HashMap<String, TransactionHistory> history = user.getHistory();
         double totalAssets = 0;
 
         HashMap<String, Double> prices = new HashMap<>();
@@ -44,12 +45,10 @@ public class DashboardInteractor extends BaseStockInteractor implements Dashboar
             prices.put(key, driverAPI.getCurrentPrice(key).getPrice());
             totalAssets += value * prices.get(key);
 
-            CompanyInformation companyInformation = driverAPI.getCompanyProfile(key);
-
             PortfolioInformation emptyInfo = new PortfolioInformation();
             emptyInfo.setAmount(value);
             emptyInfo.setTicker(key);
-            emptyInfo.setFullName(companyInformation.getName());
+            emptyInfo.setFullName(history.get(key).getStock().getFullName());
 
             portfolioInformations.add(emptyInfo);
         }
@@ -58,7 +57,6 @@ public class DashboardInteractor extends BaseStockInteractor implements Dashboar
         double totalProfit = 0;
         double sumAggregateVolume = 0;
 
-        HashMap<String, TransactionHistory> history = user.getHistory();
         LocalDate now = LocalDate.now();
 
         for (Map.Entry<String, TransactionHistory> entry : history.entrySet()) {


### PR DESCRIPTION
GetCompanyNews was only being called to get the FullName, but that is already in the transaction history.
essentially, in portfolio => in history, so we can grab the full name from the pre-queried transaction history.