### PR TITLE
BuyView Bugs

### DIFF
--- a/src/main/java/use_case/Buy/BuyInteractor.java
+++ b/src/main/java/use_case/Buy/BuyInteractor.java
@@ -80,8 +80,7 @@ public class BuyInteractor extends BaseStockInteractor implements BuyInputBounda
             return;
         }
         if (!user.hasEnough(currentPrice * amount)) {
-            buyPresenter.prepareFailView("You need $" + ((currentPrice * amount) - user.getBalance())
-                        + " more to complete this transaction.");
+            buyPresenter.prepareFailView(String.format("You need $%.2f more to complete this transaction.", (currentPrice * amount) - user.getBalance()));
             return;
         }
 

--- a/src/main/java/use_case/Buy/BuyInteractor.java
+++ b/src/main/java/use_case/Buy/BuyInteractor.java
@@ -80,7 +80,7 @@ public class BuyInteractor extends BaseStockInteractor implements BuyInputBounda
             return;
         }
         if (!user.hasEnough(currentPrice * amount)) {
-            buyPresenter.prepareFailView("You need $" + (user.getBalance() - (currentPrice * amount))
+            buyPresenter.prepareFailView("You need $" + ((currentPrice * amount) - user.getBalance())
                         + " more to complete this transaction.");
             return;
         }

--- a/src/main/java/view/BuyView.java
+++ b/src/main/java/view/BuyView.java
@@ -127,7 +127,9 @@ public class BuyView extends JPanel implements ActionListener, PropertyChangeLis
             public void keyPressed(KeyEvent e) {}
 
             @Override
-            public void keyReleased(KeyEvent e) {}
+            public void keyReleased(KeyEvent e) {
+                updateBalanceLabelColor();
+            }
         });
         this.setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
         setLayout(new BorderLayout());
@@ -255,6 +257,7 @@ public class BuyView extends JPanel implements ActionListener, PropertyChangeLis
     private void setFields(BuyState state) {
         tickerInputField.setText(state.getTicker());
         amountInputField.setText(state.getAmount());
+        updateBalanceLabelColor();
     }
 
 }


### PR DESCRIPTION
Bug related to insufficient balance error message can be seen below.
<img width="545" alt="image" src="https://github.com/awesominat/stonks/assets/113859565/7f9a8661-d83d-464f-b2a7-a0dbfc0a2128">

Bug related to insufficient balance label color can be seen below.
<img width="618" alt="image" src="https://github.com/awesominat/stonks/assets/113859565/ce3e49c1-4dab-4333-879c-4bc6b4534dfb">



I fixed the two bugs above in the BuyView.

- I fixed the sign error with the displayed missing amount of money and rounded it to two decimal places to match the normal denominations money is measured in.
<img width="453" alt="image" src="https://github.com/awesominat/stonks/assets/113859565/39079884-66c0-42d2-965b-b35338e9bc5d">

- I fixed the error where the label color did not properly update when the user was entering a quanity into the amount field.
<img width="636" alt="image" src="https://github.com/awesominat/stonks/assets/113859565/b45e99ec-d60c-4b64-91ab-8057d6b55a15">
